### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Installation
 
 Use go get.
 
-	go get github.com/go-playground/validator
+	go get github.com/go-playground/validator/v10
 
 Then import the validator package into your own code.
 
-	import "github.com/go-playground/validator"
+	import "github.com/go-playground/validator/v10"
 
 Error Return Value
 -------


### PR DESCRIPTION
fix https://github.com/go-playground/validator/issues/756

Undoes this pr? https://github.com/go-playground/validator/pull/710

Running `go get github.com/go-playground/validator/v10` definitely seems to be the right command. Go getting without the version pulls 9 or just the master. 

Also, importing without the version does not use the current version (v10 at the time of this pr).

## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
~~Tests exist or have been written that cover this particular change.~~ - Not applicable 

@go-playground/admins